### PR TITLE
Add SQLite persistence layer for activities and registrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and registrations in SQLite
 
 ## Getting Started
 
@@ -21,6 +22,9 @@ A super simple FastAPI application that allows students to view and sign up for 
    python app.py
    ```
 
+   By default, the API uses `activities.sqlite` in the `src` directory.
+   You can override this path with the `DATABASE_PATH` environment variable.
+
 3. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
@@ -31,6 +35,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                     |
 
 ## Data Model
 
@@ -47,4 +52,12 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+All data is stored in SQLite, so activities and registrations survive app restarts.
+
+## Running Tests
+
+Run persistence tests with:
+
+```
+python -m unittest discover -s src -p "test_*.py"
+```

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,8 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
+import sqlite3
+from contextlib import closing
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
@@ -19,8 +21,8 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Seed data used only when the database is first initialized.
+SEED_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +80,124 @@ activities = {
 }
 
 
+def get_db_path() -> Path:
+    return Path(os.getenv("DATABASE_PATH", str(current_dir / "activities.sqlite")))
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(get_db_path())
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def initialize_db() -> None:
+    db_path = get_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with closing(get_connection()) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL CHECK (max_participants > 0)
+            );
+
+            CREATE TABLE IF NOT EXISTS students (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE
+            );
+
+            CREATE TABLE IF NOT EXISTS registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER NOT NULL,
+                student_id INTEGER NOT NULL,
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                FOREIGN KEY(student_id) REFERENCES students(id) ON DELETE CASCADE,
+                UNIQUE(activity_id, student_id)
+            );
+            """
+        )
+
+        existing = conn.execute("SELECT COUNT(*) AS count FROM activities").fetchone()["count"]
+        if existing == 0:
+            for name, details in SEED_ACTIVITIES.items():
+                cursor = conn.execute(
+                    """
+                    INSERT INTO activities(name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        name,
+                        details["description"],
+                        details["schedule"],
+                        details["max_participants"],
+                    ),
+                )
+                activity_id = cursor.lastrowid
+
+                for email in details["participants"]:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO students(email) VALUES (?)",
+                        (email,),
+                    )
+                    student_id = conn.execute(
+                        "SELECT id FROM students WHERE email = ?",
+                        (email,),
+                    ).fetchone()["id"]
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO registrations(activity_id, student_id)
+                        VALUES (?, ?)
+                        """,
+                        (activity_id, student_id),
+                    )
+
+        conn.commit()
+
+
+def load_activities() -> dict:
+    with closing(get_connection()) as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                a.name,
+                a.description,
+                a.schedule,
+                a.max_participants,
+                s.email
+            FROM activities a
+            LEFT JOIN registrations r ON r.activity_id = a.id
+            LEFT JOIN students s ON s.id = r.student_id
+            ORDER BY a.name, s.email
+            """
+        ).fetchall()
+
+    activities = {}
+    for row in rows:
+        name = row["name"]
+        if name not in activities:
+            activities[name] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+
+        if row["email"]:
+            activities[name]["participants"].append(row["email"])
+
+    return activities
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    initialize_db()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +205,86 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return load_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with closing(get_connection()) as conn:
+        activity = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        activity_id = activity["id"]
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        current_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM registrations WHERE activity_id = ?",
+            (activity_id,),
+        ).fetchone()["count"]
+        max_participants = conn.execute(
+            "SELECT max_participants FROM activities WHERE id = ?",
+            (activity_id,),
+        ).fetchone()["max_participants"]
+        if current_count >= max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
+        conn.execute("INSERT OR IGNORE INTO students(email) VALUES (?)", (email,))
+        student_id = conn.execute(
+            "SELECT id FROM students WHERE email = ?",
+            (email,),
+        ).fetchone()["id"]
+
+        try:
+            conn.execute(
+                "INSERT INTO registrations(activity_id, student_id) VALUES (?, ?)",
+                (activity_id, student_id),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            ) from exc
+
+        conn.commit()
+
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with closing(get_connection()) as conn:
+        activity = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        student = conn.execute(
+            "SELECT id FROM students WHERE email = ?",
+            (email,),
+        ).fetchone()
+        if not student:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        result = conn.execute(
+            "DELETE FROM registrations WHERE activity_id = ? AND student_id = ?",
+            (activity["id"], student["id"]),
         )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Remove student
-    activity["participants"].remove(email)
+        conn.commit()
+
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/test_persistence.py
+++ b/src/test_persistence.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import unittest
+
+from fastapi.testclient import TestClient
+
+import app as app_module
+
+
+class TestPersistence(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test_activities.sqlite")
+        os.environ["DATABASE_PATH"] = self.db_path
+
+    def tearDown(self):
+        os.environ.pop("DATABASE_PATH", None)
+        self.temp_dir.cleanup()
+
+    def test_signup_persists_across_restart(self):
+        email = "persistence-check@mergington.edu"
+
+        with TestClient(app_module.app) as client:
+            signup_response = client.post(
+                "/activities/Chess Club/signup",
+                params={"email": email},
+            )
+            self.assertEqual(signup_response.status_code, 200)
+
+        with TestClient(app_module.app) as client:
+            activities = client.get("/activities").json()
+
+        self.assertIn(email, activities["Chess Club"]["participants"])
+
+    def test_duplicate_registration_is_rejected(self):
+        email = "duplicate-check@mergington.edu"
+
+        with TestClient(app_module.app) as client:
+            first = client.post(
+                "/activities/Programming Class/signup",
+                params={"email": email},
+            )
+            second = client.post(
+                "/activities/Programming Class/signup",
+                params={"email": email},
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 400)
+        self.assertEqual(second.json()["detail"], "Student is already signed up")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements issue #18 by replacing in-memory activity state with a persistent SQLite data layer while keeping existing API endpoints and response shape intact.

## What changed
- Added SQLite-backed schema for:
  - `activities`
  - `students`
  - `registrations` (with unique `(activity_id, student_id)` constraint)
- Added startup initialization that:
  - Creates tables if missing
  - Seeds existing activities/participants only when database is empty
- Updated endpoints in `src/app.py` to use database CRUD operations:
  - `GET /activities`
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added persistence tests in `src/test_persistence.py`:
  - Signup survives app restart
  - Duplicate signup rejected (DB uniqueness enforcement)
- Updated docs in `src/README.md` for SQLite behavior and test command

## Validation
- Ran: `python -m unittest discover -s src -p 'test_*.py'`
- Result: 2 tests passed

Closes #18